### PR TITLE
Iframe scatter

### DIFF
--- a/Frontend/Regressionpage.html
+++ b/Frontend/Regressionpage.html
@@ -5,6 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Happiness Regression</title>
+  <script src="https://d3js.org/d3.v5.min.js"></script>
+  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/superhero/bootstrap.min.css">
   <link href="https://fonts.googleapis.com/css?family=Ubuntu" rel="stylesheet">
   <link rel="stylesheet" href="static/CSS/style.css">
@@ -26,15 +28,26 @@
     </nav>
     <div class="container">
       <div class="row">
-        <div class="col-12">
-          <iframe class="map-row" src="scatterplot.html" width="100%"></iframe>
+        <div class="col-12 float-left">
+          <div class="scat-plot">
+            <div id="plot"></div>
+
+            <select id="selDataset1">
+
+              <select>
+
+                <select id="selDataset2">
+
+
+                </select>
+                <!-- <iframe class="map-row" src="scatterplot.html" width="100%"></iframe> -->
+          </div>
         </div>
       </div>
-    </div>
-    <script src="https://d3js.org/d3.v5.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0"
-      crossorigin="anonymous"></script>
+      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-b5kHyXgcpbZJO/tY9Ul7kGkf1S0CWuKcCD38l8YkeH8z8QjE0GmW1gYU5S9FOnJ0"
+        crossorigin="anonymous"></script>
+      <script src="static/js/scatterplot.js"></script>
 </body>
 <footer>
   <div class="footer">Copyright &copy; Darren Raymonds, Evan Mobley, Paul Anderson & Shreya Bakshi 2021 </div>

--- a/Frontend/Regressionpage.html
+++ b/Frontend/Regressionpage.html
@@ -27,8 +27,8 @@
       </div>
     </nav>
     <div class="container">
-      <div class="row">
-        <div class="col-12 float-left">
+      <div class="row float-left">
+        <div class="col-12">
           <div class="scat-plot">
             <div id="plot"></div>
 

--- a/Frontend/scatterplot.html
+++ b/Frontend/scatterplot.html
@@ -1,25 +1,29 @@
-<!DOCTYPE html>
+<!-- <!DOCTYPE html>
 <html lang="en">
+
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Scatter Plot</title>
-    <script src="https://d3js.org/d3.v5.min.js"></script>
-    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scatter Plot</title>
+  <script src="https://d3js.org/d3.v5.min.js"></script>
+  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 </head>
+
 <body>
-    <div id="plot"></div>
+  <div class="scat-plot">
+    <div id="plot" style=></div>
 
-  <select id="selDataset1">
-    
-  <select>
- 
-  <select id="selDataset2">
-    
-    
-  </select>
+      <select id="selDataset1">
 
+        <select>
+
+          <select id="selDataset2">
+
+
+          </select>
+  </div>
   <script src="static/js/scatterplot.js"></script>
 
 </body>
-</html>
+
+</html> -->

--- a/Frontend/static/CSS/style.css
+++ b/Frontend/static/CSS/style.css
@@ -139,9 +139,14 @@ html {
 }
 
 .map-row {
-  height: 40vw;
+  height: 50vw;
   width: 80vw
 }
+
+/* .scat-plot {
+  width: 1000px;
+  height: 800px;
+} */
 
 
 

--- a/Frontend/static/CSS/style.css
+++ b/Frontend/static/CSS/style.css
@@ -143,10 +143,9 @@ html {
   width: 80vw
 }
 
-/* .scat-plot {
-  width: 1000px;
-  height: 800px;
-} */
+.scat-plot {
+  color: black
+}
 
 
 

--- a/Frontend/static/js/scatterplot.js
+++ b/Frontend/static/js/scatterplot.js
@@ -35,8 +35,6 @@ function init() {
     var countries = response.countries;
     var year = response.year;
     var rvalue = response.r_value;
-    // Testing for functionality iframe-scatter
-    console.log(x_category_base)
 
     var trace1 = {
       x: x_data,
@@ -80,8 +78,9 @@ function init() {
       }
     };
     data = [trace1, trace2];
+    var config = {responsive: true};
 
-    Plotly.newPlot("plot", data, layout);
+    Plotly.newPlot("plot", data, layout, config);
 
     // append options to the year dropdown
     d3.json(url + "/year_list").then(function (data) {
@@ -194,14 +193,7 @@ function updatePlotly() {
     // var y_title = response.y_category
     // data = [x, y]
     Plotly.react("plot", data, layout);
-    // Plotly.restyle("plot", "y", [y]);
   });
-  // Initialize x and y arrays
-  // var x = [];
-  // var y = [];
-  // Note the extra brackets around 'x' and 'y'
-  //Plotly.restyle("plot", "x", [x]);
-  // Plotly.restyle("plot", "y", [y]);
 }
 init(
 );

--- a/Frontend/static/js/scatterplot.js
+++ b/Frontend/static/js/scatterplot.js
@@ -35,6 +35,8 @@ function init() {
     var countries = response.countries;
     var year = response.year;
     var rvalue = response.r_value;
+    // Testing for functionality iframe-scatter
+    console.log(x_category_base)
 
     var trace1 = {
       x: x_data,


### PR DESCRIPTION
I changed the scatterplot.js and Regressionpage.html to be directly connected instead of using scatterplot.html and iframing in the Plotly graph. In order to do so, I had to add the d3 and plotly script references to the top of Regressionpage.html. I had to add the reference to scatterplot.js into the bottom of the body of Regressionpage.html. U then added "var config = {responsive:true} to make the graph responsive to the width of the viewer's screen. I only had to add it to the initial function calling graphing the plotly scatter. When I tried to also add it to the "react" function, it cause the select dropdown items to dissappear after a selection was made. I also had to create a style class called "scat-plot" that defined the text font as black because the select dropdown items were inheriting their font formats from the parent divs.